### PR TITLE
Add support for .jsx.babel convention.

### DIFF
--- a/src/babel.plugin.coffee
+++ b/src/babel.plugin.coffee
@@ -13,7 +13,7 @@ module.exports = (BasePlugin) ->
 			{inExtension,outExtension,file} = opts
 
 			# Upper case the text document's content if it is using the convention txt.(uc|uppercase)
-			if inExtension in ['es6','babel'] and outExtension in ['js',null]
+			if inExtension in ['es6','babel'] and outExtension in ['js','jsx',null]
 
 				# Render synchronously
 				opts.content = babel.transform(opts.content, {}).code;


### PR DESCRIPTION
I tested this in the node_modules/docpad-plugin-babel/out/docpad-plugin-babel.js version of the file but not this coffeescript version. It worked for me with this edit to docpad project:

... `(outExtension === 'js' || outExtension === 'jsx' || outExtension === null))`... on line 21 of docpad-plugin-babel.js
